### PR TITLE
Add vendor prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Actually, all that's need is hyphenation on long words that might overflow. Thus
 ```css
 .long-word {
     hyphens: auto:
+    -ms-hyphens: auto; /* IE */
+    -webkit-hyphens: auto; /* Safari + Safari iOS */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Actually, all that's need is hyphenation on long words that might overflow. Thus
     hyphens: auto:
     -ms-hyphens: auto; /* IE */
     -webkit-hyphens: auto; /* Safari + Safari iOS */
+    word-break: break-word; /* Safari iOS */
 }
 ```
 


### PR DESCRIPTION
It turns out, not only IE, but also modern day (2022) Safari still needs a vendor prefix: https://caniuse.com/?search=hyphens